### PR TITLE
Allow Joker placement when Yachtsea is zeroed out

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -358,13 +358,13 @@ function updateYachtseaBonusOptionsForYachtsea(
     ...scorecard.yachtseaBonus.yachtseaBonusOptions,
   ];
 
-  if (!scorecard.rows[upperSectionIndex].earnedPoints) {
+  if (scorecard.rows[upperSectionIndex].earnedPoints === undefined) {
     newYachtseaBonusOptions[upperSectionIndex] = true;
   } else {
     let lowerSectionIsOpen = false;
     const lowerSectionIndexes = [6, 7, 8, 9, 10, 11, 12];
     lowerSectionIndexes.forEach((scorecardRowIndex) => {
-      if (!scorecard.rows[scorecardRowIndex].earnedPoints) {
+      if (scorecard.rows[scorecardRowIndex].earnedPoints === undefined) {
         newYachtseaBonusOptions[scorecardRowIndex] = true;
         if (!lowerSectionIsOpen) {
           lowerSectionIsOpen = true;
@@ -375,7 +375,7 @@ function updateYachtseaBonusOptionsForYachtsea(
     if (!lowerSectionIsOpen) {
       const upperSectionIndexes = [0, 1, 2, 3, 4, 5];
       upperSectionIndexes.forEach((scorecardRowIndex) => {
-        if (!scorecard.rows[scorecardRowIndex].earnedPoints) {
+        if (scorecard.rows[scorecardRowIndex].earnedPoints === undefined) {
           newYachtseaBonusOptions[scorecardRowIndex] = true;
         }
       });
@@ -386,9 +386,18 @@ function updateYachtseaBonusOptionsForYachtsea(
 }
 
 function updateYachtseaBonusOptions(dice: IDie[], scorecard: IScorecard) {
-  return checkYachtseaBonusConditions(dice, scorecard)
+  return checkJokerConditions(dice, scorecard)
     ? updateYachtseaBonusOptionsForYachtsea(dice, scorecard)
     : scorecard.yachtseaBonus.yachtseaBonusOptions;
+}
+
+// Joker rules apply whenever a Yachtsea is rolled and the Yachtsea row has
+// already been used (whether scored as 50 or zeroed out). Only the +100
+// bonus itself requires the Yachtsea row to have been scored as 50.
+function checkJokerConditions(dice: IDie[], scorecard: IScorecard) {
+  return (
+    checkForYachtseaFn(dice) && scorecard.rows[11].earnedPoints !== undefined
+  );
 }
 
 function checkYachtseaBonusConditions(dice: IDie[], scorecard: IScorecard) {


### PR DESCRIPTION
## Summary

Fixes a scoring bug where a player who had already zeroed out the Yachtsea row could not place a fresh five-of-a-kind roll into Set of 3, Set of 4, or any other lower-section box.

- Split Joker-eligibility from the +100 Yachtsea bonus check. Joker placement now activates whenever Yachtsea has been used (scored as 0 or 50); only the +100 bonus itself still requires the original Yachtsea to have been scored as 50.
- Tightened the row-emptiness checks in `updateYachtseaBonusOptionsForYachtsea` to compare `earnedPoints === undefined` instead of `!earnedPoints`, so that zeroed rows are no longer falsely treated as available Joker targets (which previously could trap a Joker on the matching upper-section box even when it was already zeroed).

### Root cause

`checkYachtseaBonusConditions` required `scorecard.rows[11].earnedPoints === 50` and was used to gate **both** the bonus counter increment and the `yachtseaBonusOptions` flags. With Yachtsea zeroed, the gate was closed, so `checkForMatchingNumbers` saw a Yachtsea roll with `isYachtseaBonusOption = false` and returned 0 for Set of 3 / Set of 4.

### Files changed

- `src/state/index.ts` — added `checkJokerConditions`, switched `updateYachtseaBonusOptions` to it, and replaced `!earnedPoints` with `earnedPoints === undefined` in the Joker placement helper.

## Test plan

- [ ] Zero out the Yachtsea row, then roll a five-of-a-kind. Confirm Set of 3 and Set of 4 light up with the sum of the dice and accept the click.
- [ ] Zero out the Yachtsea row AND the matching upper-section row (e.g. zero Yachtsea, zero Fives, then roll five 5s). Confirm the lower-section boxes are offered (and the already-zeroed Fives row stays unclickable).
- [ ] Score Yachtsea as 50, then roll another five-of-a-kind. Confirm the +100 bonus still increments and Joker placement still works.
- [ ] On a fresh game, roll a five-of-a-kind on the first scoring move. Confirm only the Yachtsea row is offered (Joker rules should not apply yet).

https://claude.ai/code/session_017uA16iXw97UkMwdZ3vm4UE

---
_Generated by [Claude Code](https://claude.ai/code/session_017uA16iXw97UkMwdZ3vm4UE)_